### PR TITLE
Refocus site on topic briefings with dropdown previews

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page not found · SGT Revision Toolkit</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="main" style="max-width: 600px; margin: 2rem auto;">
+    <h1>Page not found</h1>
+    <p>The resource you requested could not be located. Return to the <a href="index.html">home page</a> to continue revising.</p>
+  </main>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,35 @@
-echo "# SGTrevision" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/CB-Dex/SGTrevision.git
-git push -u origin main
+# SGT Revision Briefings
+
+A static set of briefing notes for the UK Police Sergeant's exam. The site emphasises short explanations over rote testing, letting you scan the key sections and references that matter most.
+
+## Features
+- Topic picker with instant previews so you can gauge where to focus next.
+- Browse view with search and tag filters to surface the right explanation quickly.
+- Concise cards that pair the section title with practical commentary and Blackstone's references.
+- Optional dark theme stored locally in the browser. No logins or analytics.
+
+## Running locally
+No tooling is required. Clone or download the repository, then open `index.html` in a modern browser (double-click it or use **File → Open**). The page will load `data.json` from the same folder and render immediately.
+
+## Deploying to GitHub Pages
+1. Push this repository to GitHub.
+2. Go to **Settings → Pages**.
+3. Select **Deploy from a branch**, choose your branch, and keep the root (`/`) folder.
+4. Save. Pages will publish the static files automatically.
+
+## Updating `data.json`
+- Keep the existing structure: topics → subtopics → cards. Each card includes `id`, `subtopic_id`, `question`, `answer`, `reference`, `subtitle`, `tags`, and optional `explanation`.
+- Assign new numeric IDs when adding material. This keeps existing links intact.
+- Because the site no longer tracks quiz progress, you can freely edit wording without affecting browser storage.
+- Refresh the browser after saving edits to load the latest content.
+
+### CSV planning template
+When drafting in a spreadsheet, use:
+```
+id,subtopic_id,question,answer,reference,subtitle,tags,explanation
+```
+- Separate multiple tags with a pipe (e.g. `mens rea|OAPA`).
+- Leave `explanation` blank if a single paragraph is enough.
+
+## How search works
+The browse search matches keywords across the question, answer, subtitle, reference, topic, subtopic, and tags fields. Filter dropdowns narrow the list by topic or tag for faster access to the most relevant guidance.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,464 @@
+(function () {
+  const THEME_KEY = 'sgt-theme';
+
+  const state = {
+    data: null,
+    indexes: {},
+    route: window.location.hash || '#home',
+    theme: 'light',
+    activeTopic: 'all',
+    search: {
+      term: '',
+      topic: 'all',
+      tag: 'all'
+    }
+  };
+
+  const topicSummaries = {
+    'non-fatal-offences': {
+      summary:
+        'Focus on how intent, harm level, and lawful excuses shape charging decisions for assault-based offences.',
+      highlights: [
+        'Differentiate apprehension-based assault from contact offences.',
+        'Recognise the thresholds for ABH, wounding, and grievous bodily harm.',
+        'Link lawful force and necessity defences to practical scenarios.'
+      ]
+    },
+    'theft-related': {
+      summary:
+        'Understand how appropriation, dishonesty, and property concepts interact under the Theft Act and connected offences.',
+      highlights: [
+        'Break down appropriation and ownership rights for theft.',
+        'Spot the knowledge elements in handling stolen goods.',
+        'Apply the objective dishonesty test to fraud scenarios.'
+      ]
+    },
+    'criminal-damage': {
+      summary:
+        'Examine how intention, recklessness, and lawful excuse operate for damage to property, including life-endangerment cases.',
+      highlights: [
+        'Separate simple and aggravated criminal damage requirements.',
+        'Use lawful excuse provisions when property is damaged to protect people.',
+        'Confirm what counts as property within the legislation.'
+      ]
+    }
+  };
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  function init() {
+    document.documentElement.classList.remove('no-js');
+    loadTheme();
+    bindGlobalEvents();
+    fetchData();
+  }
+
+  function bindGlobalEvents() {
+    window.addEventListener('hashchange', handleRouteChange);
+
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+      themeToggle.addEventListener('click', toggleTheme);
+      updateThemeToggleLabel();
+    }
+
+    const topicSelect = document.getElementById('topic-select');
+    if (topicSelect) {
+      topicSelect.addEventListener('change', (event) => {
+        const value = event.target.value;
+        state.activeTopic = value;
+        renderTopicPreview();
+        if (value === 'all') {
+          if (!state.route.startsWith('#browse')) {
+            window.location.hash = '#browse';
+          } else {
+            handleRouteChange();
+          }
+        } else {
+          window.location.hash = `#topic/${value}`;
+        }
+      });
+    }
+  }
+
+  function fetchData() {
+    fetch('data.json')
+      .then((res) => res.json())
+      .then((data) => {
+        state.data = data;
+        buildIndexes();
+        populateTopicSelect();
+        renderTopicPreview();
+        handleRouteChange();
+      })
+      .catch((err) => {
+        console.error('Failed to load data.json', err);
+        renderError('Unable to load briefing notes. Please refresh the page.');
+      });
+  }
+
+  function buildIndexes() {
+    const topicMap = new Map();
+    const topicBySlug = new Map();
+    const subtopicMap = new Map();
+    const subtopicsByTopic = new Map();
+
+    state.data.topics.forEach((topic) => {
+      topicMap.set(topic.id, topic);
+      topicBySlug.set(topic.slug, topic);
+      subtopicsByTopic.set(topic.id, []);
+    });
+
+    state.data.subtopics.forEach((subtopic) => {
+      subtopicMap.set(subtopic.id, subtopic);
+      const list = subtopicsByTopic.get(subtopic.topic_id) || [];
+      list.push(subtopic);
+      subtopicsByTopic.set(subtopic.topic_id, list);
+    });
+
+    state.indexes = {
+      topicMap,
+      topicBySlug,
+      subtopicMap,
+      subtopicsByTopic
+    };
+  }
+
+  function populateTopicSelect() {
+    const select = document.getElementById('topic-select');
+    if (!select || !state.data) return;
+    const options = ['<option value="all">All topics</option>'].concat(
+      state.data.topics.map(
+        (topic) => `<option value="${topic.slug}">${escapeHtml(topic.title)}</option>`
+      )
+    );
+    select.innerHTML = options.join('');
+    select.value = state.activeTopic;
+  }
+
+  function renderTopicPreview() {
+    const preview = document.getElementById('topic-preview');
+    if (!preview) return;
+
+    if (!state.data) {
+      preview.textContent = '';
+      return;
+    }
+
+    if (state.activeTopic === 'all') {
+      preview.innerHTML =
+        '<p>Select a topic to see a quick outline of the key sections covered in these briefings.</p>';
+      return;
+    }
+
+    const info = topicSummaries[state.activeTopic];
+    const topic = state.indexes.topicBySlug.get(state.activeTopic);
+    if (!info || !topic) {
+      preview.textContent = '';
+      return;
+    }
+
+    preview.innerHTML = `
+      <strong>${escapeHtml(topic.title)}:</strong>
+      <span>${escapeHtml(info.summary)}</span>
+    `;
+  }
+
+  function handleRouteChange() {
+    state.route = window.location.hash || '#home';
+
+    if (state.route.startsWith('#topic/')) {
+      const slug = state.route.replace('#topic/', '');
+      state.activeTopic = slug;
+      const select = document.getElementById('topic-select');
+      if (select) {
+        select.value = slug;
+      }
+      renderTopicPreview();
+    }
+
+    if (!state.data) {
+      return;
+    }
+
+    const main = document.getElementById('app');
+    main.innerHTML = '';
+
+    if (state.route === '#home') {
+      renderHome(main);
+    } else if (state.route === '#browse') {
+      renderBrowse(main);
+    } else if (state.route.startsWith('#topic/')) {
+      renderTopic(main);
+    } else if (state.route === '#about') {
+      renderAbout(main);
+    } else {
+      renderNotFound(main);
+    }
+
+    setTimeout(() => main.focus(), 0);
+  }
+
+  function renderHome(container) {
+    const sectionsHtml = state.data.topics
+      .map((topic) => {
+        const summary = topicSummaries[topic.slug];
+        if (!summary) return '';
+        const highlights = summary.highlights
+          .map((item) => `<li>${escapeHtml(item)}</li>`)
+          .join('');
+        return `
+          <article class="card">
+            <header>
+              <h3>${escapeHtml(topic.title)}</h3>
+              <p class="subtitle">${escapeHtml(summary.summary)}</p>
+            </header>
+            <ul class="topic-summary-list">${highlights}</ul>
+          </article>
+        `;
+      })
+      .join('');
+
+    container.innerHTML = `
+      <section aria-labelledby="home-title">
+        <h2 id="home-title">Briefings built for quick understanding</h2>
+        <p>
+          Each note distils legislation and procedure into the points you need for confident application on the exam and on shift.
+          Browse by topic or scroll through the key sections below to refresh understanding without drilling quizzes.
+        </p>
+        <div class="card-list">
+          ${sectionsHtml}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderBrowse(container) {
+    const tags = collectTags();
+    container.innerHTML = `
+      <section aria-labelledby="browse-title">
+        <h2 id="browse-title">Browse briefing notes</h2>
+        <p>Search across explanations, references, and tags to locate the section you need.</p>
+        <div class="search-bar" role="search">
+          <label class="sr-only" for="search-input">Search notes</label>
+          <input id="search-input" class="search-input" type="search" placeholder="Search explanations or references" value="${state.search.term}" aria-label="Search notes">
+          <label class="sr-only" for="topic-filter">Filter by topic</label>
+          <select id="topic-filter" aria-label="Filter by topic">
+            <option value="all">All topics</option>
+            ${state.data.topics
+              .map(
+                (topic) => `<option value="${topic.slug}" ${state.search.topic === topic.slug ? 'selected' : ''}>${escapeHtml(topic.title)}</option>`
+              )
+              .join('')}
+          </select>
+          <label class="sr-only" for="tag-filter">Filter by tag</label>
+          <select id="tag-filter" aria-label="Filter by tag">
+            <option value="all">All tags</option>
+            ${tags
+              .map((tag) => `<option value="${tag}" ${state.search.tag === tag ? 'selected' : ''}>${escapeHtml(tag)}</option>`)
+              .join('')}
+          </select>
+        </div>
+        <div id="browse-results" class="card-list" aria-live="polite"></div>
+      </section>
+    `;
+
+    const searchInput = container.querySelector('#search-input');
+    const topicFilter = container.querySelector('#topic-filter');
+    const tagFilter = container.querySelector('#tag-filter');
+
+    const debouncedSearch = debounce((value) => {
+      state.search.term = value;
+      updateBrowseResults();
+    }, 200);
+
+    searchInput?.addEventListener('input', (event) => {
+      debouncedSearch(event.target.value);
+    });
+
+    topicFilter?.addEventListener('change', (event) => {
+      state.search.topic = event.target.value;
+      updateBrowseResults();
+    });
+
+    tagFilter?.addEventListener('change', (event) => {
+      state.search.tag = event.target.value;
+      updateBrowseResults();
+    });
+
+    updateBrowseResults();
+  }
+
+  function updateBrowseResults() {
+    const container = document.getElementById('browse-results');
+    if (!container) return;
+
+    let cards = state.data.cards.slice();
+
+    if (state.search.topic !== 'all') {
+      cards = cards.filter((card) => {
+        const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+        const topic = subtopic ? state.indexes.topicMap.get(subtopic.topic_id) : null;
+        return topic?.slug === state.search.topic;
+      });
+    }
+
+    if (state.search.tag !== 'all') {
+      cards = cards.filter((card) => card.tags.includes(state.search.tag));
+    }
+
+    if (state.search.term) {
+      cards = cards.filter((card) => searchableText(card).includes(state.search.term.toLowerCase()));
+    }
+
+    if (cards.length === 0) {
+      container.innerHTML = '<p>No notes match the current filters.</p>';
+      return;
+    }
+
+    container.innerHTML = cards.map((card) => renderCard(card)).join('');
+  }
+
+  function renderTopic(container) {
+    const slug = state.route.replace('#topic/', '');
+    const topic = state.indexes.topicBySlug.get(slug);
+    if (!topic) {
+      renderNotFound(container);
+      return;
+    }
+    const summary = topicSummaries[slug];
+    const cards = state.data.cards.filter((card) => {
+      const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+      return subtopic?.topic_id === topic.id;
+    });
+
+    const highlights = summary
+      ? summary.highlights.map((item) => `<li>${escapeHtml(item)}</li>`).join('')
+      : '';
+
+    container.innerHTML = `
+      <section aria-labelledby="topic-title">
+        <h2 id="topic-title">${escapeHtml(topic.title)}</h2>
+        ${summary ? `<p>${escapeHtml(summary.summary)}</p>` : ''}
+        ${highlights ? `<ul class="topic-summary-list">${highlights}</ul>` : ''}
+        <div class="card-list" style="margin-top: 1.5rem;">
+          ${cards.map((card) => renderCard(card)).join('')}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderAbout(container) {
+    container.innerHTML = `
+      <section aria-labelledby="about-title">
+        <h2 id="about-title">About these briefings</h2>
+        <p>
+          The toolkit distils essential sections from the Sergeant exam syllabus into concise explanations. Instead of drilling memory-based questions, each entry emphasises why the section matters, how it is applied, and the reference to return to within Blackstone's.
+        </p>
+        <p>
+          Use the topic picker to skim outlines, then dive into the browse view when you need the full narrative, supporting tags, and pinpoint references.
+        </p>
+        <p>
+          Content is stored locally; no accounts or tracking are involved. Toggle the colour theme to suit your environment.
+        </p>
+      </section>
+    `;
+  }
+
+  function renderNotFound(container) {
+    container.innerHTML = `
+      <section>
+        <h2>Page not found</h2>
+        <p>The page you requested could not be located. Choose another section from the navigation.</p>
+      </section>
+    `;
+  }
+
+  function renderError(message) {
+    const main = document.getElementById('app');
+    if (main) {
+      main.innerHTML = `<section><h2>Error</h2><p>${escapeHtml(message)}</p></section>`;
+    }
+  }
+
+  function renderCard(card) {
+    const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+    const topic = subtopic ? state.indexes.topicMap.get(subtopic.topic_id) : null;
+    return `
+      <article class="card" aria-label="${escapeHtml(card.question)}">
+        <header>
+          <h3>${escapeHtml(card.question)}</h3>
+          <p class="subtitle">${escapeHtml(card.subtitle)}${topic ? ` · ${escapeHtml(topic.title)}` : ''}</p>
+          <p class="reference">${escapeHtml(card.reference)}</p>
+        </header>
+        <div class="body">
+          <p>${escapeHtml(card.answer)}</p>
+          ${card.explanation ? `<p>${escapeHtml(card.explanation)}</p>` : ''}
+          <div class="card-tags">
+            ${card.tags.map((tag) => `<span>${escapeHtml(tag)}</span>`).join('')}
+          </div>
+        </div>
+      </article>
+    `;
+  }
+
+  function collectTags() {
+    const tagSet = new Set();
+    state.data.cards.forEach((card) => {
+      card.tags.forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }
+
+  function searchableText(card) {
+    const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+    const topic = subtopic ? state.indexes.topicMap.get(subtopic.topic_id) : null;
+    const text = [card.question, card.answer, card.reference, card.subtitle, ...(card.tags || [])];
+    if (subtopic) text.push(subtopic.title);
+    if (topic) text.push(topic.title);
+    return text.join(' ').toLowerCase();
+  }
+
+  function loadTheme() {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored) {
+      state.theme = stored;
+    }
+    applyTheme();
+  }
+
+  function toggleTheme() {
+    state.theme = state.theme === 'dark' ? 'light' : 'dark';
+    applyTheme();
+    localStorage.setItem(THEME_KEY, state.theme);
+  }
+
+  function applyTheme() {
+    document.body.setAttribute('data-theme', state.theme);
+    updateThemeToggleLabel();
+  }
+
+  function updateThemeToggleLabel() {
+    const button = document.getElementById('theme-toggle');
+    if (!button) return;
+    button.textContent = state.theme === 'dark' ? 'Light mode' : 'Dark mode';
+  }
+
+  function escapeHtml(str) {
+    if (str == null) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function debounce(fn, wait) {
+    let timeout;
+    return function (...args) {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(this, args), wait);
+    };
+  }
+})();

--- a/data.json
+++ b/data.json
@@ -1,0 +1,147 @@
+{
+  "topics": [
+    { "id": 1, "title": "Non-Fatal Offences", "slug": "non-fatal-offences" },
+    { "id": 2, "title": "Theft & Related", "slug": "theft-related" },
+    { "id": 3, "title": "Criminal Damage", "slug": "criminal-damage" }
+  ],
+  "subtopics": [
+    { "id": 1, "topic_id": 1, "title": "Common Assault", "slug": "common-assault" },
+    { "id": 2, "topic_id": 1, "title": "ABH & Wounding", "slug": "abh-wounding" },
+    { "id": 3, "topic_id": 2, "title": "Theft Act Basics", "slug": "theft-act-basics" },
+    { "id": 4, "topic_id": 2, "title": "Handling & Fraud", "slug": "handling-fraud" },
+    { "id": 5, "topic_id": 3, "title": "Simple Damage", "slug": "simple-damage" },
+    { "id": 6, "topic_id": 3, "title": "Aggravated Damage", "slug": "aggravated-damage" }
+  ],
+  "cards": [
+    {
+      "id": 1,
+      "subtopic_id": 1,
+      "question": "Which element best describes the actus reus of common assault?",
+      "answer": "Causing another to apprehend immediate unlawful violence",
+      "reference": "Blackstone's, Crime 2025, 1.16.2 p.219",
+      "subtitle": "Assault essentials",
+      "tags": ["actus reus", "assault"],
+      "explanation": "Common assault requires an act causing apprehension of immediate unlawful force; no physical contact is needed."
+    },
+    {
+      "id": 2,
+      "subtopic_id": 1,
+      "question": "What level of harm is required for a charge under s.39 Criminal Justice Act 1988?",
+      "answer": "No injury is necessary; fear alone suffices",
+      "reference": "Blackstone's, Crime 2025, 1.16.4 p.221",
+      "subtitle": "CJA 1988 scope",
+      "tags": ["CJA 1988", "non-fatal"]
+    },
+    {
+      "id": 3,
+      "subtopic_id": 1,
+      "question": "Which defence can lawfully justify the use of force in a common assault scenario?",
+      "answer": "Self-defence if force is reasonable and necessary",
+      "reference": "Blackstone's, Crime 2025, 1.18.1 p.227",
+      "subtitle": "Lawful force",
+      "tags": ["defences", "self-defence"]
+    },
+    {
+      "id": 4,
+      "subtopic_id": 2,
+      "question": "Under s.47 Offences Against the Person Act 1861, what additional element elevates assault to ABH?",
+      "answer": "Occasioning actual bodily harm",
+      "reference": "Blackstone's, Crime 2025, 1.19.5 p.234",
+      "subtitle": "ABH elements",
+      "tags": ["ABH", "OAPA"],
+      "explanation": "ABH requires proof that the assault occasioned injuries more than trivial but not necessarily permanent."
+    },
+    {
+      "id": 5,
+      "subtopic_id": 2,
+      "question": "For s.20 OAPA 1861, what mens rea must the prosecution prove?",
+      "answer": "Intention or recklessness as to inflicting some harm",
+      "reference": "Blackstone's, Crime 2025, 1.19.9 p.236",
+      "subtitle": "Wounding mens rea",
+      "tags": ["OAPA", "mens rea"]
+    },
+    {
+      "id": 6,
+      "subtopic_id": 2,
+      "question": "Which injury best illustrates 'grievous bodily harm' for s.18 OAPA?",
+      "answer": "Serious injury causing long-term impairment",
+      "reference": "Blackstone's, Crime 2025, 1.19.11 p.237",
+      "subtitle": "GBH threshold",
+      "tags": ["GBH", "serious harm"]
+    },
+    {
+      "id": 7,
+      "subtopic_id": 3,
+      "question": "What is the definition of 'appropriation' under s.3 Theft Act 1968?",
+      "answer": "Any assumption of the rights of the owner",
+      "reference": "Blackstone's, Crime 2025, 2.4.2 p.311",
+      "subtitle": "Appropriation defined",
+      "tags": ["theft act", "appropriation"],
+      "explanation": "Assuming any of the owner's rights is sufficient; no need for all rights to be taken."
+    },
+    {
+      "id": 8,
+      "subtopic_id": 3,
+      "question": "For theft, which combination completes the actus reus?",
+      "answer": "Appropriation of property belonging to another",
+      "reference": "Blackstone's, Crime 2025, 2.4.5 p.313",
+      "subtitle": "Actus reus trio",
+      "tags": ["property", "actus reus"]
+    },
+    {
+      "id": 9,
+      "subtopic_id": 4,
+      "question": "Handling stolen goods requires the defendant to know or believe what?",
+      "answer": "The goods are stolen at the time of handling",
+      "reference": "Blackstone's, Crime 2025, 2.12.3 p.341",
+      "subtitle": "Mental element",
+      "tags": ["handling", "mens rea"]
+    },
+    {
+      "id": 10,
+      "subtopic_id": 4,
+      "question": "Under the Fraud Act 2006, dishonesty is assessed using which test?",
+      "answer": "The Ivey objective standards of ordinary decent people",
+      "reference": "Blackstone's, Crime 2025, 2.18.1 p.365",
+      "subtitle": "Dishonesty test",
+      "tags": ["fraud", "dishonesty"]
+    },
+    {
+      "id": 11,
+      "subtopic_id": 5,
+      "question": "What is required for the mens rea of simple criminal damage?",
+      "answer": "Intention or recklessness as to damaging property",
+      "reference": "Blackstone's, Crime 2025, 3.2.4 p.401",
+      "subtitle": "Mens rea focus",
+      "tags": ["criminal damage", "mens rea"]
+    },
+    {
+      "id": 12,
+      "subtopic_id": 5,
+      "question": "A defendant breaks a window to rescue a child from fire. Which defence is most relevant?",
+      "answer": "Lawful excuse under s.5(2)(b) Criminal Damage Act",
+      "reference": "Blackstone's, Crime 2025, 3.3.2 p.407",
+      "subtitle": "Lawful excuse",
+      "tags": ["defences", "necessity"]
+    },
+    {
+      "id": 13,
+      "subtopic_id": 6,
+      "question": "Aggravated criminal damage under s.1(2) CDA requires proof of what additional element?",
+      "answer": "Intention or recklessness as to endangering life",
+      "reference": "Blackstone's, Crime 2025, 3.4.1 p.413",
+      "subtitle": "Endangering life",
+      "tags": ["aggravated", "endanger life"],
+      "explanation": "The prosecution must show the defendant intended or was reckless about life being endangered by the damage."
+    },
+    {
+      "id": 14,
+      "subtopic_id": 6,
+      "question": "Which property type can be the subject of criminal damage?",
+      "answer": "Tangible property including land and buildings",
+      "reference": "Blackstone's, Crime 2025, 3.2.1 p.399",
+      "subtitle": "Property scope",
+      "tags": ["property", "CDA"]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SGT Revision Briefings</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header" role="banner">
+        <div class="header-inner">
+            <div class="brand">
+                <span class="brand-badge" aria-hidden="true"></span>
+                <div>
+                    <h1>SGT Revision Briefings</h1>
+                    <p class="tagline">Quick explanations for key Sergeant exam sections</p>
+                </div>
+            </div>
+            <div class="header-actions">
+                <div class="topic-selector">
+                    <label for="topic-select">Topics</label>
+                    <select id="topic-select" aria-label="Choose a topic">
+                        <option value="all">All topics</option>
+                    </select>
+                </div>
+                <button id="theme-toggle" class="button secondary" aria-label="Toggle colour theme"></button>
+            </div>
+        </div>
+        <div id="topic-preview" class="topic-preview" aria-live="polite"></div>
+    </header>
+
+    <nav class="primary-nav" aria-label="Primary">
+        <a href="#home">Home</a>
+        <a href="#browse">Browse</a>
+        <a href="#about">About</a>
+    </nav>
+
+    <main id="app" class="main" role="main" tabindex="-1">
+        <section class="loading" aria-live="polite">
+            <p>Loading briefing notes…</p>
+        </section>
+    </main>
+
+    <footer class="site-footer" role="contentinfo">
+        <p>Concise study notes derived from Blackstone's Police Sergeants' &amp; Inspectors' Manual references.</p>
+    </footer>
+
+    <noscript>
+        <div class="noscript">This site requires JavaScript to load study content. Please enable JavaScript in your browser.</div>
+    </noscript>
+
+    <script src="app.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,333 @@
+:root {
+    color-scheme: light dark;
+    --font-body: 'Helvetica Neue', Arial, sans-serif;
+    --font-size-base: 17px;
+    --color-text: #111;
+    --color-background: #fafafa;
+    --color-surface: #ffffff;
+    --color-border: #d0d4d9;
+    --color-accent: #224b8f;
+    --color-muted: #5a626c;
+    --color-focus: #ffbf47;
+    --color-tag-bg: #e7ebf0;
+    --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="dark"] {
+    --color-text: #f4f5f7;
+    --color-background: #0f1114;
+    --color-surface: #15181d;
+    --color-border: #2e3238;
+    --color-accent: #82b1ff;
+    --color-muted: #9ea6b3;
+    --color-tag-bg: #222830;
+    --shadow: 0 12px 36px rgba(0, 0, 0, 0.6);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--font-size-base);
+    background: var(--color-background);
+    color: var(--color-text);
+    min-height: 100%;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}
+
+.no-js body {
+    display: block;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1rem 1.5rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.brand-badge {
+    width: 44px;
+    height: 44px;
+    background: var(--color-accent);
+    border-radius: 12px;
+}
+
+.brand h1 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.tagline {
+    margin: 0.2rem 0 0;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.header-actions {
+    display: flex;
+    align-items: flex-end;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.topic-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.95rem;
+}
+
+.topic-selector label {
+    color: var(--color-muted);
+}
+
+.topic-selector select {
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: inherit;
+    font-size: 1rem;
+}
+
+.topic-preview {
+    border-top: 1px solid var(--color-border);
+    padding: 0.85rem 1.5rem 1rem;
+    background: var(--color-surface);
+    max-width: 1000px;
+    margin: 0 auto;
+    font-size: 0.98rem;
+    color: var(--color-muted);
+}
+
+.primary-nav {
+    display: flex;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.primary-nav a {
+    color: var(--color-accent);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.25rem 0.5rem;
+    border-radius: 6px;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus {
+    background: rgba(34, 75, 143, 0.1);
+}
+
+.button {
+    background: var(--color-accent);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 0.55rem 1rem;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.button.secondary {
+    background: transparent;
+    color: var(--color-accent);
+    border: 1px solid var(--color-accent);
+}
+
+.button:hover,
+.button:focus {
+    background: #173665;
+    color: #fff;
+}
+
+.button.secondary:hover,
+.button.secondary:focus {
+    background: var(--color-accent);
+    color: #fff;
+}
+
+.button:focus-visible {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 1px;
+}
+
+.main {
+    flex: 1;
+    padding: 1.5rem;
+}
+
+section {
+    max-width: 1000px;
+    margin: 0 auto;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 14px;
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+}
+
+section + section {
+    margin-top: 2rem;
+}
+
+h2 {
+    margin-top: 0;
+    font-size: 1.6rem;
+}
+
+p {
+    line-height: 1.6;
+}
+
+.card-list {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.card {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    background: var(--color-surface);
+    box-shadow: var(--shadow);
+}
+
+.card header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.card .subtitle {
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.card .reference {
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    align-self: flex-end;
+}
+
+.card .body {
+    margin-top: 1rem;
+}
+
+.card-tags {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
+}
+
+.card-tags span {
+    background: var(--color-tag-bg);
+    color: inherit;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+}
+
+.search-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.search-bar input,
+.search-bar select {
+    padding: 0.6rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    font-size: 1rem;
+}
+
+.search-bar input:focus,
+.search-bar select:focus {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 1px;
+}
+
+.topic-summary-list {
+    margin: 1rem 0 0;
+    padding: 0;
+    list-style: none;
+    display: grid;
+    gap: 0.4rem;
+}
+
+.topic-summary-list li::before {
+    content: "•";
+    color: var(--color-accent);
+    margin-right: 0.5rem;
+}
+
+.site-footer {
+    background: var(--color-surface);
+    border-top: 1px solid var(--color-border);
+    padding: 1.25rem 1.5rem;
+    text-align: center;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.noscript {
+    padding: 1rem;
+    background: #ffdd00;
+    color: #0b0c0c;
+    text-align: center;
+    font-weight: 600;
+}
+
+@media (max-width: 700px) {
+    .header-inner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .header-actions {
+        width: 100%;
+        align-items: stretch;
+    }
+
+    .primary-nav {
+        padding: 0.75rem;
+    }
+
+    section {
+        padding: 1.5rem;
+    }
+}


### PR DESCRIPTION
## Summary
- replace the sidebar layout with a header topic dropdown and preview messaging to encourage quick topic selection
- remove quiz and flashcard tooling in favour of explanatory browse and topic views styled for concise briefings
- refresh documentation to describe the briefing-focused experience and updated data guidance

## Testing
- python -m json.tool data.json

------
https://chatgpt.com/codex/tasks/task_e_68d962de911883268f960ca1d94296f2