### PR TITLE
Expand topic catalogue and refresh study layout

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Page not found · SGT Revision Toolkit</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <main class="main" style="max-width: 600px; margin: 2rem auto;">
+    <h1>Page not found</h1>
+    <p>The resource you requested could not be located. Return to the <a href="index.html">home page</a> to continue revising.</p>
+  </main>
+</body>
+</html>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,28 @@
-echo "# SGTrevision" >> README.md
-git init
-git add README.md
-git commit -m "first commit"
-git branch -M main
-git remote add origin https://github.com/CB-Dex/SGTrevision.git
-git push -u origin main
+# SGT Revision Toolkit
+
+A fast, accessible static site that maps every topic in the Blackstone's Police Sergeants' & Inspectors' Manuals. The toolkit lists all chapters across the Crime, Evidence & Procedure, and General Police Duties volumes and pairs them with quick reference study cards.
+
+## Features
+- Header topic picker with live preview of chapter counts and highlights.
+- Home overview showing the complete breakdown of every chapter for each Blackstone's volume.
+- Browse view for filtering and searching study cards by topic, keyword, or tag.
+- Lightweight dark-mode toggle stored locally in the browser.
+
+## Running locally
+No build step is required. Clone or download the repository and open `index.html` in a modern browser (double-click the file or use **File → Open**). The app loads `data.json` from the same folder.
+
+## Deploying to GitHub Pages
+1. Push this repository to GitHub.
+2. In your repository, open **Settings → Pages**.
+3. Under **Source**, choose **Deploy from a branch** and select the branch that contains these files. Ensure the folder is set to `/ (root)`.
+4. Save. GitHub Pages will serve the static files directly.
+
+## Updating `data.json`
+- `topics` describe the three main volumes. Each topic has many `subtopics` representing the full chapter list supplied by Blackstone's.
+- Each study `card` references a `subtopic_id`, includes a `question`, `answer`, `reference`, `subtitle`, and an array of `tags`. Optional `explanation` text adds extra context.
+- Add new cards by appending to the `cards` array. Keep IDs unique so that localStorage references remain stable for returning users.
+- The preview counts and home overview update automatically when data changes.
+
+## Notes
+- All references cite Blackstone's 2025 content, published by Wildy & Sons.
+- Feel free to adapt the styling in `styles.css` to suit your branding while preserving accessible colour contrast.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,524 @@
+(function () {
+  const THEME_KEY = 'sgt-theme';
+
+  const blackstonesCatalogue = [
+    {
+      title: 'Crime',
+      slug: 'crime',
+      summary:
+        'Sixteen chapters covering foundational principles and major offences within the Blackstone\'s crime volume.',
+      chapters: [
+        'Mens Rea (State of Mind)',
+        'Actus Reus (Criminal Conduct)',
+        'Incomplete Offences',
+        'General Defences',
+        'Homicide',
+        'Misuse of Drugs',
+        'Firearms and Gun Crime',
+        'Racially and Religiously Aggravated Offences',
+        'Non-fatal Offences Against the Person',
+        'Miscellaneous Offences Against the Person and Offences Involving the Deprivation of Liberty',
+        'Sexual Offences',
+        'Child Protection',
+        'Theft and Related Offences',
+        'Fraud',
+        'Criminal Damage',
+        'Offences Against the Administration of Justice and Public Interest'
+      ]
+    },
+    {
+      title: 'Evidence & Procedure',
+      slug: 'evidence-procedure',
+      summary:
+        'Eight procedure-focused chapters following the lifecycle of an investigation through to presentation in court.',
+      chapters: [
+        'Instituting Criminal Proceedings',
+        'Release of Person Arrested',
+        'Court Procedure and Witnesses',
+        'Exclusion of Admissible Evidence',
+        'Disclosure of Evidence',
+        'Detention and Treatment of Persons by Police Officers: PACE Code C',
+        'Identification: PACE Code D',
+        'Interviews: PACE Codes C, E and F'
+      ]
+    },
+    {
+      title: 'General Police Duties',
+      slug: 'general-police-duties',
+      summary:
+        'Twenty-two operational chapters spanning public protection, public order, community safeguarding, and road policing.',
+      chapters: [
+        'Stop and Search',
+        'Entry, Search and Seizure',
+        'Powers of Arrest',
+        'Protection of People Suffering from Mental Disorders',
+        'Offences Relating to Land and Premises',
+        'Licensing and Offences',
+        'Protecting Citizens and the Community: Injunctions, Orders, and Police Powers',
+        'Policing Processions, Assemblies and Protests; Offences and Powers',
+        'Public Order Offences',
+        'Sporting Events',
+        'Domestic Violence and Abuse',
+        'Hatred and Harassment Offences',
+        'Offences and Powers Relating to Information and Communications',
+        'Offences Against the Administration of Justice and Public Interest',
+        'Terrorism and Associated Offences',
+        'Diversity, Equality and Inclusion',
+        'Complaints and Misconduct',
+        'Unsatisfactory Performance and Attendance',
+        'Road Policing Definitions and Principles',
+        'Key Police Powers Relating to Road Policing',
+        'Offences Involving Standards of Driving',
+        'Drink, Drugs and Driving'
+      ]
+    }
+  ];
+
+  const state = {
+    data: null,
+    indexes: {},
+    route: window.location.hash || '#home',
+    theme: 'light',
+    activeTopic: 'all',
+    search: {
+      term: '',
+      topic: 'all',
+      tag: 'all'
+    },
+    catalogueMap: new Map()
+  };
+
+  document.addEventListener('DOMContentLoaded', init);
+
+  function init() {
+    document.documentElement.classList.remove('no-js');
+    loadTheme();
+    bindGlobalEvents();
+    buildCatalogueMap();
+    fetchData();
+  }
+
+  function buildCatalogueMap() {
+    state.catalogueMap = new Map();
+    blackstonesCatalogue.forEach((topic) => {
+      state.catalogueMap.set(topic.slug, topic);
+    });
+  }
+
+  function bindGlobalEvents() {
+    window.addEventListener('hashchange', handleRouteChange);
+
+    const themeToggle = document.getElementById('theme-toggle');
+    if (themeToggle) {
+      themeToggle.addEventListener('click', toggleTheme);
+      updateThemeToggleLabel();
+    }
+
+    const topicSelect = document.getElementById('topic-select');
+    if (topicSelect) {
+      topicSelect.addEventListener('change', (event) => {
+        const value = event.target.value;
+        state.activeTopic = value;
+        renderTopicPreview();
+        if (value === 'all') {
+          if (!state.route.startsWith('#browse')) {
+            window.location.hash = '#browse';
+          } else {
+            handleRouteChange();
+          }
+        } else {
+          window.location.hash = `#topic/${value}`;
+        }
+      });
+    }
+  }
+
+  function fetchData() {
+    fetch('data.json')
+      .then((res) => res.json())
+      .then((data) => {
+        state.data = data;
+        buildIndexes();
+        populateTopicSelect();
+        renderTopicPreview();
+        handleRouteChange();
+      })
+      .catch((err) => {
+        console.error('Failed to load data.json', err);
+        renderError('Unable to load study cards. Please refresh the page.');
+      });
+  }
+
+  function buildIndexes() {
+    const topicMap = new Map();
+    const topicBySlug = new Map();
+    const subtopicMap = new Map();
+    const subtopicsByTopic = new Map();
+
+    state.data.topics.forEach((topic) => {
+      topicMap.set(topic.id, topic);
+      topicBySlug.set(topic.slug, topic);
+      subtopicsByTopic.set(topic.id, []);
+    });
+
+    state.data.subtopics.forEach((subtopic) => {
+      subtopicMap.set(subtopic.id, subtopic);
+      const list = subtopicsByTopic.get(subtopic.topic_id) || [];
+      list.push(subtopic);
+      subtopicsByTopic.set(subtopic.topic_id, list);
+    });
+
+    state.indexes = {
+      topicMap,
+      topicBySlug,
+      subtopicMap,
+      subtopicsByTopic
+    };
+  }
+
+  function populateTopicSelect() {
+    const select = document.getElementById('topic-select');
+    if (!select) return;
+    const options = ['<option value="all">All topics</option>'].concat(
+      blackstonesCatalogue.map(
+        (topic) => `<option value="${topic.slug}">${escapeHtml(topic.title)}</option>`
+      )
+    );
+    select.innerHTML = options.join('');
+    select.value = state.activeTopic;
+  }
+
+  function renderTopicPreview() {
+    const preview = document.getElementById('topic-preview');
+    if (!preview) return;
+
+    if (state.activeTopic === 'all') {
+      preview.innerHTML = '<p>Select a topic to see the chapter breakdown and related study cards.</p>';
+      return;
+    }
+
+    const catalogue = state.catalogueMap.get(state.activeTopic);
+    const topic = state.indexes.topicBySlug?.get(state.activeTopic);
+
+    if (!catalogue || !topic) {
+      preview.textContent = '';
+      return;
+    }
+
+    const previewChapters = catalogue.chapters
+      .slice(0, 3)
+      .map((item) => `<li>${escapeHtml(item)}</li>`)
+      .join('');
+
+    preview.innerHTML = `
+      <div>
+        <strong>${escapeHtml(topic.title)}</strong>
+        <p>${escapeHtml(catalogue.summary)}</p>
+        <p class="preview-count">${catalogue.chapters.length} chapters</p>
+        <ul class="preview-list">${previewChapters}</ul>
+        <p class="preview-footnote">View the full breakdown on the topic page.</p>
+      </div>
+    `;
+  }
+
+  function handleRouteChange() {
+    state.route = window.location.hash || '#home';
+
+    if (state.route.startsWith('#topic/')) {
+      const slug = state.route.replace('#topic/', '');
+      state.activeTopic = slug;
+      const select = document.getElementById('topic-select');
+      if (select) {
+        select.value = slug;
+      }
+      renderTopicPreview();
+    }
+
+    if (!state.data) {
+      return;
+    }
+
+    const main = document.getElementById('app');
+    main.innerHTML = '';
+
+    if (state.route === '#home') {
+      renderHome(main);
+    } else if (state.route === '#browse') {
+      renderBrowse(main);
+    } else if (state.route.startsWith('#topic/')) {
+      renderTopic(main);
+    } else if (state.route === '#about') {
+      renderAbout(main);
+    } else {
+      renderNotFound(main);
+    }
+
+    setTimeout(() => main.focus(), 0);
+  }
+
+  function renderHome(container) {
+    const cardsByTopic = countCardsByTopic();
+    const catalogueHtml = blackstonesCatalogue
+      .map((topic) => {
+        const topicCount = cardsByTopic.get(topic.slug) || 0;
+        const chapters = topic.chapters.map((chapter) => `<li>${escapeHtml(chapter)}</li>`).join('');
+        return `
+          <article class="topic-card">
+            <header>
+              <h3>${escapeHtml(topic.title)}</h3>
+              <p class="subtitle">${escapeHtml(topic.summary)}</p>
+              <p class="chapter-count">${topic.chapters.length} chapters · ${topicCount} study cards</p>
+            </header>
+            <ul class="chapter-list">${chapters}</ul>
+            <div class="topic-actions">
+              <a class="button secondary" href="#topic/${topic.slug}">Open topic</a>
+            </div>
+          </article>
+        `;
+      })
+      .join('');
+
+    container.innerHTML = `
+      <section aria-labelledby="home-title">
+        <h2 id="home-title">Blackstone's syllabus at a glance</h2>
+        <p>Use this overview to explore every topic required for the UK Police Sergeant's exam. Each section below lists the chapters contained within the official Blackstone's manuals and links directly to the supporting study cards.</p>
+        <div class="topic-grid">
+          ${catalogueHtml}
+        </div>
+      </section>
+    `;
+  }
+
+  function renderBrowse(container) {
+    const tags = collectTags();
+    container.innerHTML = `
+      <section aria-labelledby="browse-title">
+        <h2 id="browse-title">Browse study cards</h2>
+        <p>Search by keyword, filter by topic, or focus on specific tags to surface the explanations you need.</p>
+        <div class="search-bar" role="search">
+          <label class="sr-only" for="search-input">Search cards</label>
+          <input id="search-input" class="search-input" type="search" placeholder="Search questions, answers, or references" value="${state.search.term}" aria-label="Search cards">
+          <label class="sr-only" for="topic-filter">Filter by topic</label>
+          <select id="topic-filter" aria-label="Filter by topic">
+            <option value="all">All topics</option>
+            ${blackstonesCatalogue
+              .map(
+                (topic) => `<option value="${topic.slug}" ${state.search.topic === topic.slug ? 'selected' : ''}>${escapeHtml(topic.title)}</option>`
+              )
+              .join('')}
+          </select>
+          <label class="sr-only" for="tag-filter">Filter by tag</label>
+          <select id="tag-filter" aria-label="Filter by tag">
+            <option value="all">All tags</option>
+            ${tags
+              .map((tag) => `<option value="${tag}" ${state.search.tag === tag ? 'selected' : ''}>${escapeHtml(tag)}</option>`)
+              .join('')}
+          </select>
+        </div>
+        <div id="browse-results" class="card-list" aria-live="polite"></div>
+      </section>
+    `;
+
+    const searchInput = container.querySelector('#search-input');
+    const topicFilter = container.querySelector('#topic-filter');
+    const tagFilter = container.querySelector('#tag-filter');
+
+    const debouncedSearch = debounce((value) => {
+      state.search.term = value;
+      updateBrowseResults();
+    }, 200);
+
+    searchInput?.addEventListener('input', (event) => {
+      debouncedSearch(event.target.value);
+    });
+
+    topicFilter?.addEventListener('change', (event) => {
+      state.search.topic = event.target.value;
+      updateBrowseResults();
+    });
+
+    tagFilter?.addEventListener('change', (event) => {
+      state.search.tag = event.target.value;
+      updateBrowseResults();
+    });
+
+    updateBrowseResults();
+  }
+
+  function updateBrowseResults() {
+    const container = document.getElementById('browse-results');
+    if (!container) return;
+
+    let cards = state.data.cards.slice();
+
+    if (state.search.topic !== 'all') {
+      cards = cards.filter((card) => {
+        const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+        const topic = subtopic ? state.indexes.topicMap.get(subtopic.topic_id) : null;
+        return topic?.slug === state.search.topic;
+      });
+    }
+
+    if (state.search.tag !== 'all') {
+      cards = cards.filter((card) => card.tags.includes(state.search.tag));
+    }
+
+    if (state.search.term) {
+      cards = cards.filter((card) => searchableText(card).includes(state.search.term.toLowerCase()));
+    }
+
+    container.innerHTML = cards.length
+      ? cards.map((card) => renderCard(card)).join('')
+      : '<p>No cards match the current filters.</p>';
+  }
+
+  function renderTopic(container) {
+    const slug = state.route.replace('#topic/', '');
+    const topicRecord = state.indexes.topicBySlug.get(slug);
+    const catalogue = state.catalogueMap.get(slug);
+
+    if (!topicRecord || !catalogue) {
+      renderNotFound(container);
+      return;
+    }
+
+    const cards = state.data.cards.filter((card) => {
+      const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+      return subtopic?.topic_id === topicRecord.id;
+    });
+
+    const subtopics = catalogue.chapters.map((chapter) => `<li>${escapeHtml(chapter)}</li>`).join('');
+
+    container.innerHTML = `
+      <section aria-labelledby="topic-title">
+        <h2 id="topic-title">${escapeHtml(topicRecord.title)}</h2>
+        <p>${escapeHtml(catalogue.summary)}</p>
+        <p class="chapter-count">${catalogue.chapters.length} chapters</p>
+        <h3>Chapter breakdown</h3>
+        <ul class="chapter-list">${subtopics}</ul>
+        <h3>Study cards</h3>
+        <div class="card-list">${cards.map((card) => renderCard(card)).join('') || '<p>Cards for this topic are coming soon.</p>'}</div>
+      </section>
+    `;
+  }
+
+  function renderAbout(container) {
+    container.innerHTML = `
+      <section aria-labelledby="about-title">
+        <h2 id="about-title">About this site</h2>
+        <p>SGT Revision Toolkit is a static reference built around the official Blackstone's Police Sergeants' and Inspectors' Manuals. It highlights every chapter across the crime, evidence & procedure, and general police duties volumes, pairing them with concise study cards that distil key legal tests.</p>
+        <p>Use the topic selector in the header to jump between volumes, review the chapter breakdowns, and read the linked cards when you need quick clarification.</p>
+        <p>All data is stored locally in your browser, and the site runs entirely offline once loaded.</p>
+      </section>
+    `;
+  }
+
+  function renderNotFound(container) {
+    container.innerHTML = `
+      <section>
+        <h2>Page not found</h2>
+        <p>The requested page could not be located. Please choose another section from the navigation.</p>
+      </section>
+    `;
+  }
+
+  function renderError(message) {
+    const main = document.getElementById('app');
+    if (main) {
+      main.innerHTML = `<section><h2>Error</h2><p>${escapeHtml(message)}</p></section>`;
+    }
+  }
+
+  function renderCard(card) {
+    const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+    const topic = subtopic ? state.indexes.topicMap.get(subtopic.topic_id) : null;
+    return `
+      <article class="card" aria-label="${escapeHtml(card.question)}">
+        <header>
+          <h3>${escapeHtml(card.question)}</h3>
+          <p class="subtitle">${escapeHtml(card.subtitle)}${topic ? ` · ${escapeHtml(topic.title)}` : ''}</p>
+          <p class="reference">${escapeHtml(card.reference)}</p>
+        </header>
+        <div class="body">
+          <p><strong>Answer:</strong> ${escapeHtml(card.answer)}</p>
+          ${card.explanation ? `<p>${escapeHtml(card.explanation)}</p>` : ''}
+          <div class="card-tags">
+            ${card.tags.map((tag) => `<span>${escapeHtml(tag)}</span>`).join('')}
+          </div>
+        </div>
+      </article>
+    `;
+  }
+
+  function countCardsByTopic() {
+    const counts = new Map();
+    if (!state.data) return counts;
+    state.data.cards.forEach((card) => {
+      const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+      const topic = subtopic ? state.indexes.topicMap.get(subtopic.topic_id) : null;
+      if (!topic) return;
+      counts.set(topic.slug, (counts.get(topic.slug) || 0) + 1);
+    });
+    return counts;
+  }
+
+  function collectTags() {
+    const tagSet = new Set();
+    state.data.cards.forEach((card) => {
+      card.tags.forEach((tag) => tagSet.add(tag));
+    });
+    return Array.from(tagSet).sort();
+  }
+
+  function searchableText(card) {
+    const subtopic = state.indexes.subtopicMap.get(card.subtopic_id);
+    const topic = subtopic ? state.indexes.topicMap.get(subtopic.topic_id) : null;
+    const text = [card.question, card.answer, card.reference, card.subtitle, ...(card.tags || [])];
+    if (subtopic) text.push(subtopic.title);
+    if (topic) text.push(topic.title);
+    return text.join(' ').toLowerCase();
+  }
+
+  function loadTheme() {
+    const stored = localStorage.getItem(THEME_KEY);
+    if (stored) {
+      state.theme = stored;
+    }
+    applyTheme();
+  }
+
+  function toggleTheme() {
+    state.theme = state.theme === 'dark' ? 'light' : 'dark';
+    applyTheme();
+    localStorage.setItem(THEME_KEY, state.theme);
+  }
+
+  function applyTheme() {
+    document.body.setAttribute('data-theme', state.theme);
+    updateThemeToggleLabel();
+  }
+
+  function updateThemeToggleLabel() {
+    const button = document.getElementById('theme-toggle');
+    if (!button) return;
+    button.textContent = state.theme === 'dark' ? 'Light mode' : 'Dark mode';
+  }
+
+  function escapeHtml(str) {
+    if (str == null) return '';
+    return String(str)
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#39;');
+  }
+
+  function debounce(fn, wait) {
+    let timeout;
+    return function (...args) {
+      clearTimeout(timeout);
+      timeout = setTimeout(() => fn.apply(this, args), wait);
+    };
+  }
+})();

--- a/data.json
+++ b/data.json
@@ -1,0 +1,171 @@
+{
+  "topics": [
+    { "id": 1, "title": "Crime", "slug": "crime" },
+    { "id": 2, "title": "Evidence & Procedure", "slug": "evidence-procedure" },
+    { "id": 3, "title": "General Police Duties", "slug": "general-police-duties" }
+  ],
+  "subtopics": [
+    { "id": 1, "topic_id": 1, "title": "Mens Rea (State of Mind)", "slug": "mens-rea" },
+    { "id": 2, "topic_id": 1, "title": "Actus Reus (Criminal Conduct)", "slug": "actus-reus" },
+    { "id": 3, "topic_id": 1, "title": "Incomplete Offences", "slug": "incomplete-offences" },
+    { "id": 4, "topic_id": 1, "title": "General Defences", "slug": "general-defences" },
+    { "id": 5, "topic_id": 1, "title": "Homicide", "slug": "homicide" },
+    { "id": 6, "topic_id": 1, "title": "Misuse of Drugs", "slug": "misuse-of-drugs" },
+    { "id": 7, "topic_id": 1, "title": "Firearms and Gun Crime", "slug": "firearms" },
+    { "id": 8, "topic_id": 1, "title": "Racially and Religiously Aggravated Offences", "slug": "racially-aggravated" },
+    { "id": 9, "topic_id": 1, "title": "Non-fatal Offences Against the Person", "slug": "non-fatal-offences" },
+    { "id": 10, "topic_id": 1, "title": "Miscellaneous Offences Against the Person and Offences Involving the Deprivation of Liberty", "slug": "misc-offences" },
+    { "id": 11, "topic_id": 1, "title": "Sexual Offences", "slug": "sexual-offences" },
+    { "id": 12, "topic_id": 1, "title": "Child Protection", "slug": "child-protection" },
+    { "id": 13, "topic_id": 1, "title": "Theft and Related Offences", "slug": "theft" },
+    { "id": 14, "topic_id": 1, "title": "Fraud", "slug": "fraud" },
+    { "id": 15, "topic_id": 1, "title": "Criminal Damage", "slug": "criminal-damage" },
+    { "id": 16, "topic_id": 1, "title": "Offences Against the Administration of Justice and Public Interest", "slug": "administration-of-justice" },
+    { "id": 17, "topic_id": 2, "title": "Instituting Criminal Proceedings", "slug": "instituting-proceedings" },
+    { "id": 18, "topic_id": 2, "title": "Release of Person Arrested", "slug": "release-of-person-arrested" },
+    { "id": 19, "topic_id": 2, "title": "Court Procedure and Witnesses", "slug": "court-procedure" },
+    { "id": 20, "topic_id": 2, "title": "Exclusion of Admissible Evidence", "slug": "exclusion-of-evidence" },
+    { "id": 21, "topic_id": 2, "title": "Disclosure of Evidence", "slug": "disclosure-of-evidence" },
+    { "id": 22, "topic_id": 2, "title": "Detention and Treatment of Persons by Police Officers: PACE Code C", "slug": "pace-code-c" },
+    { "id": 23, "topic_id": 2, "title": "Identification: PACE Code D", "slug": "pace-code-d" },
+    { "id": 24, "topic_id": 2, "title": "Interviews: PACE Codes C, E and F", "slug": "pace-codes-c-e-f" },
+    { "id": 25, "topic_id": 3, "title": "Stop and Search", "slug": "stop-and-search" },
+    { "id": 26, "topic_id": 3, "title": "Entry, Search and Seizure", "slug": "entry-search-seizure" },
+    { "id": 27, "topic_id": 3, "title": "Powers of Arrest", "slug": "powers-of-arrest" },
+    { "id": 28, "topic_id": 3, "title": "Protection of People Suffering from Mental Disorders", "slug": "mental-disorder-protection" },
+    { "id": 29, "topic_id": 3, "title": "Offences Relating to Land and Premises", "slug": "land-premises" },
+    { "id": 30, "topic_id": 3, "title": "Licensing and Offences", "slug": "licensing" },
+    { "id": 31, "topic_id": 3, "title": "Protecting Citizens and the Community: Injunctions, Orders, and Police Powers", "slug": "injunctions-orders" },
+    { "id": 32, "topic_id": 3, "title": "Policing Processions, Assemblies and Protests; Offences and Powers", "slug": "processions-protests" },
+    { "id": 33, "topic_id": 3, "title": "Public Order Offences", "slug": "public-order-offences" },
+    { "id": 34, "topic_id": 3, "title": "Sporting Events", "slug": "sporting-events" },
+    { "id": 35, "topic_id": 3, "title": "Domestic Violence and Abuse", "slug": "domestic-violence" },
+    { "id": 36, "topic_id": 3, "title": "Hatred and Harassment Offences", "slug": "hatred-harassment" },
+    { "id": 37, "topic_id": 3, "title": "Offences and Powers Relating to Information and Communications", "slug": "information-communications" },
+    { "id": 38, "topic_id": 3, "title": "Offences Against the Administration of Justice and Public Interest", "slug": "gpd-administration-of-justice" },
+    { "id": 39, "topic_id": 3, "title": "Terrorism and Associated Offences", "slug": "terrorism" },
+    { "id": 40, "topic_id": 3, "title": "Diversity, Equality and Inclusion", "slug": "diversity-inclusion" },
+    { "id": 41, "topic_id": 3, "title": "Complaints and Misconduct", "slug": "complaints-misconduct" },
+    { "id": 42, "topic_id": 3, "title": "Unsatisfactory Performance and Attendance", "slug": "performance-attendance" },
+    { "id": 43, "topic_id": 3, "title": "Road Policing Definitions and Principles", "slug": "road-policing-definitions" },
+    { "id": 44, "topic_id": 3, "title": "Key Police Powers Relating to Road Policing", "slug": "road-policing-powers" },
+    { "id": 45, "topic_id": 3, "title": "Offences Involving Standards of Driving", "slug": "standards-of-driving" },
+    { "id": 46, "topic_id": 3, "title": "Drink, Drugs and Driving", "slug": "drink-drugs-driving" }
+  ],
+  "cards": [
+    {
+      "id": 1,
+      "subtopic_id": 1,
+      "question": "Under the R v G test, what must the prosecution show about the defendant's awareness of risk?",
+      "answer": "That they were aware of the risk and unreasonably went on to take it",
+      "reference": "Blackstone's, Crime 2025, 1.4.3 p.112",
+      "subtitle": "Subjective recklessness",
+      "tags": ["mens rea", "recklessness"],
+      "explanation": "R v G re-established that recklessness requires the defendant to foresee the risk and take it anyway." 
+    },
+    {
+      "id": 2,
+      "subtopic_id": 9,
+      "question": "Which element best describes the actus reus of common assault?",
+      "answer": "Causing another to apprehend immediate unlawful violence",
+      "reference": "Blackstone's, Crime 2025, 1.16.2 p.219",
+      "subtitle": "Assault essentials",
+      "tags": ["actus reus", "assault"],
+      "explanation": "Common assault can be committed without physical contact where the victim fears immediate unlawful force." 
+    },
+    {
+      "id": 3,
+      "subtopic_id": 13,
+      "question": "What is the definition of 'appropriation' under s.3 Theft Act 1968?",
+      "answer": "Any assumption of the rights of the owner",
+      "reference": "Blackstone's, Crime 2025, 2.4.2 p.311",
+      "subtitle": "Appropriation defined",
+      "tags": ["theft", "property"],
+      "explanation": "Assuming any of the owner's rights is sufficient; the defendant need not assume all rights." 
+    },
+    {
+      "id": 4,
+      "subtopic_id": 15,
+      "question": "What mental element is required for basic criminal damage under s.1(1) CDA 1971?",
+      "answer": "Intention or recklessness as to damaging property",
+      "reference": "Blackstone's, Crime 2025, 3.2.4 p.401",
+      "subtitle": "Mens rea focus",
+      "tags": ["criminal damage", "mens rea"]
+    },
+    {
+      "id": 5,
+      "subtopic_id": 17,
+      "question": "Which document usually commences an either-way offence in the magistrates' court?",
+      "answer": "A written charge with requisition",
+      "reference": "Blackstone's, Evidence & Procedure 2025, 4.2.1 p.52",
+      "subtitle": "Starting proceedings",
+      "tags": ["proceedings", "charging"],
+      "explanation": "For most either-way offences the CPS issues a written charge and requisition to bring the defendant before the court." 
+    },
+    {
+      "id": 6,
+      "subtopic_id": 21,
+      "question": "What is the prosecutor's core duty under the CPIA 1996 disclosure regime?",
+      "answer": "To disclose material that might reasonably undermine the prosecution or assist the defence",
+      "reference": "Blackstone's, Evidence & Procedure 2025, 9.3.2 p.132",
+      "subtitle": "Disclosure test",
+      "tags": ["disclosure", "CPIA"]
+    },
+    {
+      "id": 7,
+      "subtopic_id": 22,
+      "question": "Within what maximum period must detainees be generally reviewed under PACE Code C?",
+      "answer": "At least every six hours by the custody officer",
+      "reference": "Blackstone's, Evidence & Procedure 2025, 10.5.1 p.158",
+      "subtitle": "Custody reviews",
+      "tags": ["PACE", "custody"],
+      "explanation": "The custody officer must carry out reviews not more than six hours apart to ensure the detention remains lawful." 
+    },
+    {
+      "id": 8,
+      "subtopic_id": 23,
+      "question": "When must an identification procedure be held under PACE Code D?",
+      "answer": "When the suspect disputes identification and it is practicable and useful",
+      "reference": "Blackstone's, Evidence & Procedure 2025, 11.4.2 p.188",
+      "subtitle": "ID procedures",
+      "tags": ["PACE", "identification"]
+    },
+    {
+      "id": 9,
+      "subtopic_id": 25,
+      "question": "Under s.1 PACE, what threshold must be met before exercising a stop and search for stolen goods?",
+      "answer": "Reasonable grounds for suspicion based on objective factors",
+      "reference": "Blackstone's, General Duties 2025, 1.3.1 p.12",
+      "subtitle": "Stop and search test",
+      "tags": ["PACE", "stop and search"]
+    },
+    {
+      "id": 10,
+      "subtopic_id": 27,
+      "question": "Which criteria must be satisfied for a lawful arrest without warrant under s.24 PACE?",
+      "answer": "Reasonable suspicion plus necessity under the statutory grounds",
+      "reference": "Blackstone's, General Duties 2025, 3.2.4 p.54",
+      "subtitle": "Arrest necessity",
+      "tags": ["arrest", "PACE"],
+      "explanation": "Even with reasonable suspicion, the arresting officer must establish that arrest is necessary for one of the s.24(5) reasons." 
+    },
+    {
+      "id": 11,
+      "subtopic_id": 32,
+      "question": "Which legislation primarily governs imposing conditions on public processions?",
+      "answer": "Public Order Act 1986, section 12",
+      "reference": "Blackstone's, General Duties 2025, 7.1.2 p.118",
+      "subtitle": "Procession powers",
+      "tags": ["public order", "processions"]
+    },
+    {
+      "id": 12,
+      "subtopic_id": 46,
+      "question": "What is the prescribed limit for alcohol in breath for driving in England and Wales?",
+      "answer": "35 microgrammes of alcohol per 100 millilitres of breath",
+      "reference": "Blackstone's, General Duties 2025, 16.4.1 p.268",
+      "subtitle": "Drink drive limit",
+      "tags": ["road policing", "drink driving"]
+    }
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html>
+<html lang="en" class="no-js">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>SGT Revision Toolkit</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <header class="site-header" role="banner">
+        <div class="header-inner">
+            <div class="brand">
+                <span class="brand-badge" aria-hidden="true"></span>
+                <div>
+                    <h1>SGT Revision Toolkit</h1>
+                    <p class="tagline">Complete Blackstone's chapter map with supporting study cards</p>
+                </div>
+            </div>
+            <div class="header-actions">
+                <div class="topic-selector">
+                    <label for="topic-select">Topics</label>
+                    <select id="topic-select" aria-label="Choose a topic">
+                        <option value="all">All topics</option>
+                    </select>
+                </div>
+                <button id="theme-toggle" class="button secondary" aria-label="Toggle colour theme"></button>
+            </div>
+        </div>
+        <div id="topic-preview" class="topic-preview" aria-live="polite"></div>
+    </header>
+
+    <nav class="primary-nav" aria-label="Primary">
+        <a href="#home">Home</a>
+        <a href="#browse">Browse</a>
+        <a href="#about">About</a>
+    </nav>
+
+    <main id="app" class="main" role="main" tabindex="-1">
+        <section class="loading" aria-live="polite">
+            <p>Loading study cards…</p>
+        </section>
+    </main>
+
+    <footer class="site-footer" role="contentinfo">
+        <p>References draw on Blackstone's Police Sergeants' &amp; Inspectors' Manuals published by Wildy &amp; Sons.</p>
+    </footer>
+
+    <noscript>
+        <div class="noscript">This site requires JavaScript to load study content. Please enable JavaScript in your browser.</div>
+    </noscript>
+
+    <script src="app.js" defer></script>
+</body>
+</html>

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,403 @@
+:root {
+    color-scheme: light dark;
+    --font-body: 'Helvetica Neue', Arial, sans-serif;
+    --font-size-base: 17px;
+    --color-text: #111;
+    --color-background: #fafafa;
+    --color-surface: #ffffff;
+    --color-border: #d0d4d9;
+    --color-accent: #224b8f;
+    --color-muted: #5a626c;
+    --color-focus: #ffbf47;
+    --color-tag-bg: #e7ebf0;
+    --shadow: 0 10px 30px rgba(0, 0, 0, 0.08);
+}
+
+[data-theme="dark"] {
+    --color-text: #f4f5f7;
+    --color-background: #0f1114;
+    --color-surface: #15181d;
+    --color-border: #2e3238;
+    --color-accent: #82b1ff;
+    --color-muted: #9ea6b3;
+    --color-tag-bg: #222830;
+    --shadow: 0 12px 36px rgba(0, 0, 0, 0.6);
+}
+
+* {
+    box-sizing: border-box;
+}
+
+html,
+body {
+    margin: 0;
+    font-family: var(--font-body);
+    font-size: var(--font-size-base);
+    background: var(--color-background);
+    color: var(--color-text);
+    min-height: 100%;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
+}
+
+.no-js body {
+    display: block;
+}
+
+.site-header {
+    position: sticky;
+    top: 0;
+    z-index: 50;
+    background: var(--color-surface);
+    border-bottom: 1px solid var(--color-border);
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.05);
+}
+
+.header-inner {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1.5rem;
+    padding: 1rem 1.5rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.brand {
+    display: flex;
+    align-items: center;
+    gap: 1rem;
+}
+
+.brand-badge {
+    width: 44px;
+    height: 44px;
+    background: var(--color-accent);
+    border-radius: 12px;
+}
+
+.brand h1 {
+    margin: 0;
+    font-size: 1.5rem;
+}
+
+.tagline {
+    margin: 0.2rem 0 0;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.header-actions {
+    display: flex;
+    align-items: flex-end;
+    gap: 1rem;
+    flex-wrap: wrap;
+}
+
+.topic-selector {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+    font-size: 0.95rem;
+}
+
+.topic-selector label {
+    color: var(--color-muted);
+}
+
+.topic-selector select {
+    padding: 0.5rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    color: inherit;
+    font-size: 1rem;
+}
+
+.topic-preview {
+    border-top: 1px solid var(--color-border);
+    padding: 0.85rem 1.5rem 1rem;
+    background: var(--color-surface);
+    max-width: 1000px;
+    margin: 0 auto;
+    font-size: 0.98rem;
+    color: var(--color-muted);
+}
+
+.topic-preview ul {
+    margin: 0.5rem 0 0;
+    padding-left: 1.25rem;
+}
+
+.topic-preview li {
+    margin-bottom: 0.25rem;
+}
+
+.topic-preview .preview-count {
+    font-weight: 600;
+}
+
+.topic-preview .preview-footnote {
+    margin-top: 0.5rem;
+    font-size: 0.85rem;
+}
+
+.primary-nav {
+    display: flex;
+    gap: 1rem;
+    padding: 0.75rem 1.5rem;
+    max-width: 1000px;
+    margin: 0 auto;
+}
+
+.primary-nav a {
+    color: var(--color-accent);
+    text-decoration: none;
+    font-weight: 600;
+    padding: 0.25rem 0.5rem;
+    border-radius: 6px;
+}
+
+.primary-nav a:hover,
+.primary-nav a:focus {
+    background: rgba(34, 75, 143, 0.1);
+}
+
+.button {
+    background: var(--color-accent);
+    color: #fff;
+    border: none;
+    border-radius: 6px;
+    padding: 0.55rem 1rem;
+    font-size: 1rem;
+    cursor: pointer;
+    transition: background 0.2s ease;
+}
+
+.button.secondary {
+    background: transparent;
+    color: var(--color-accent);
+    border: 1px solid var(--color-accent);
+}
+
+.button:hover,
+.button:focus {
+    background: #173665;
+    color: #fff;
+}
+
+.button.secondary:hover,
+.button.secondary:focus {
+    background: var(--color-accent);
+    color: #fff;
+}
+
+.button:focus-visible {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 1px;
+}
+
+.main {
+    flex: 1;
+    padding: 1.5rem;
+}
+
+section {
+    max-width: 1000px;
+    margin: 0 auto;
+    background: var(--color-surface);
+    border: 1px solid var(--color-border);
+    border-radius: 14px;
+    padding: 1.75rem;
+    box-shadow: var(--shadow);
+}
+
+section + section {
+    margin-top: 2rem;
+}
+
+h2 {
+    margin-top: 0;
+    font-size: 1.6rem;
+}
+
+p {
+    line-height: 1.6;
+}
+
+.topic-grid {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.topic-card {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    background: var(--color-surface);
+    box-shadow: var(--shadow);
+}
+
+.topic-card header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-bottom: 1rem;
+}
+
+.topic-card .chapter-count {
+    font-size: 0.9rem;
+    color: var(--color-muted);
+}
+
+.chapter-list {
+    margin: 0;
+    padding-left: 1.25rem;
+    columns: 1;
+    column-gap: 1.5rem;
+}
+
+.chapter-list li {
+    margin-bottom: 0.35rem;
+}
+
+.topic-actions {
+    margin-top: 1.25rem;
+}
+
+.card-list {
+    display: grid;
+    gap: 1.25rem;
+}
+
+.card {
+    border: 1px solid var(--color-border);
+    border-radius: 12px;
+    padding: 1.5rem;
+    background: var(--color-surface);
+    box-shadow: var(--shadow);
+}
+
+.card header {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+}
+
+.card .subtitle {
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.card .reference {
+    color: var(--color-muted);
+    font-size: 0.85rem;
+    align-self: flex-end;
+}
+
+.card .body {
+    margin-top: 1rem;
+}
+
+.card-tags {
+    display: flex;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
+}
+
+.card-tags span {
+    background: var(--color-tag-bg);
+    color: inherit;
+    padding: 0.2rem 0.6rem;
+    border-radius: 999px;
+    font-size: 0.8rem;
+}
+
+.search-bar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1.5rem;
+}
+
+.search-bar input,
+.search-bar select {
+    padding: 0.6rem 0.75rem;
+    border-radius: 6px;
+    border: 1px solid var(--color-border);
+    background: var(--color-surface);
+    font-size: 1rem;
+}
+
+.search-bar input:focus,
+.search-bar select:focus {
+    outline: 3px solid var(--color-focus);
+    outline-offset: 1px;
+}
+
+.site-footer {
+    background: var(--color-surface);
+    border-top: 1px solid var(--color-border);
+    padding: 1.25rem 1.5rem;
+    text-align: center;
+    color: var(--color-muted);
+    font-size: 0.95rem;
+}
+
+.noscript {
+    padding: 1rem;
+    background: #ffdd00;
+    color: #0b0c0c;
+    text-align: center;
+    font-weight: 600;
+}
+
+@media (min-width: 960px) {
+    .topic-grid {
+        grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .chapter-list {
+        columns: 2;
+    }
+}
+
+@media (max-width: 700px) {
+    .header-inner {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .header-actions {
+        width: 100%;
+        align-items: stretch;
+    }
+
+    .primary-nav {
+        padding: 0.75rem;
+    }
+
+    section {
+        padding: 1.5rem;
+    }
+
+    .chapter-list {
+        columns: 1;
+    }
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+}


### PR DESCRIPTION
## Summary
- add the full Blackstone's chapter catalogue with updated card data for crime, evidence & procedure, and general police duties
- update the client routing to surface chapter breakdowns on the home, topic preview, and topic detail views while renaming browse mode
- refresh styling and documentation to match the study card experience and updated references

## Testing
- python -m json.tool data.json

------
https://chatgpt.com/codex/tasks/task_e_68d962de911883268f960ca1d94296f2